### PR TITLE
Add leaderboard charts with names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 This project is part of a hands-on lesson designed for 4th to 6th grade students to introduce them to the world of artificial intelligence. Using Google's Teachable Machine, students create their own image classification models by training them on pictures of five different animals.
 
 ## Visualising evaluation results
-After running `Evaluate_Student_Submissions.py`, the evaluation metrics are stored in `src/Data/Test/results.json`. The script `src/visualize_results.py` reads this file and creates two charts:
+After running `Evaluate_Student_Submissions.py`, the evaluation metrics are stored in `src/Data/Test/results.json`. The script `src/visualize_results.py` reads this file and creates three charts:
 
-1. **Accuracy of all students** – displays the accuracy for each student anonymously.
-2. **Top three students** – shows both accuracy and mean precision for the three best students including their names.
+1. **Leaderboard of all students** – shows the accuracy for every participant with their name and the value displayed on top of each bar.
+2. **Second and third place** – displays only the names and accuracies of the second and third ranked students.
+3. **Third place only** – shows the accuracy of the student ranked third.
 
 Run the visualisation with:
 
@@ -13,4 +14,4 @@ Run the visualisation with:
 python src/visualize_results.py
 ```
 
-The generated images `accuracy_overall.png` and `top3_accuracy_precision.png` will appear in the current directory.
+The generated images `leaderboard_all.png`, `leaderboard_second_third.png` and `leaderboard_third.png` will appear in the current directory.

--- a/src/visualize_results.py
+++ b/src/visualize_results.py
@@ -15,55 +15,86 @@ def load_results(path: str) -> List[Dict[str, float]]:
     return data
 
 
-def plot_overall_accuracy(results: List[Dict[str, float]]) -> None:
-    """Plot accuracy for all students without showing their names."""
+def plot_leaderboard_all(results: List[Dict[str, float]]) -> None:
+    """Plot accuracy for all students including their names and values."""
+    # results are assumed to be sorted already
+    names = [entry["student"] for entry in results]
     accuracies = [entry["accuracy"] for entry in results]
-    x = range(1, len(accuracies) + 1)
+    x = range(len(names))
 
-    plt.figure(figsize=(8, 5))
-    plt.bar(x, accuracies, color="skyblue")
+    plt.figure(figsize=(10, 6))
+    bars = plt.bar(x, accuracies, color="skyblue")
+
     plt.xlabel("Student")
     plt.ylabel("Accuracy")
     plt.title("Accuracy of all students")
-    plt.xticks(x, [str(i) for i in x])
+    plt.xticks(x, names, rotation=45, ha="right")
     plt.ylim(0, 1)
+
+    for bar, acc in zip(bars, accuracies):
+        plt.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.01,
+                 f"{acc:.2f}", ha="center", va="bottom")
+
     plt.tight_layout()
-    plt.savefig("accuracy_overall.png")
+    plt.savefig("leaderboard_all.png")
     plt.close()
 
 
-def plot_top3(results: List[Dict[str, float]]) -> None:
-    """Plot accuracy and mean precision of the best three students."""
-    # Sort by accuracy then mean_confidence
-    sorted_results = sorted(results, key=lambda x: (x["accuracy"], x["mean_confidence"]), reverse=True)
-    top3 = sorted_results[:3]
+def _sort_leaderboard(results: List[Dict[str, float]]) -> List[Dict[str, float]]:
+    """Return leaderboard sorted by accuracy and mean confidence."""
+    return sorted(results, key=lambda x: (x["accuracy"], x.get("mean_confidence", 0)), reverse=True)
 
-    names = [entry["student"] for entry in top3]
-    accuracies = [entry["accuracy"] for entry in top3]
-    precisions = [entry["mean_confidence"] for entry in top3]
 
-    x = range(len(top3))
-    width = 0.35
+def plot_second_and_third(results: List[Dict[str, float]]) -> None:
+    """Plot the accuracy of the 2nd and 3rd ranked students."""
+    lb = _sort_leaderboard(results)
+    top_entries = lb[1:3] if len(lb) >= 3 else lb[1:]
 
-    plt.figure(figsize=(8, 5))
-    plt.bar([xi - width/2 for xi in x], accuracies, width=width, label="Accuracy", color="steelblue")
-    plt.bar([xi + width/2 for xi in x], precisions, width=width, label="Mean Precision", color="orange")
+    names = [entry["student"] for entry in top_entries]
+    accuracies = [entry["accuracy"] for entry in top_entries]
 
+    x = range(len(top_entries))
+
+    plt.figure(figsize=(6, 4))
+    plt.bar(x, accuracies, color="steelblue")
     plt.xlabel("Student")
-    plt.ylabel("Value")
-    plt.title("Top 3 Students")
+    plt.ylabel("Accuracy")
+    plt.title("2nd and 3rd Place")
     plt.xticks(x, names)
     plt.ylim(0, 1)
-    plt.legend()
     plt.tight_layout()
-    plt.savefig("top3_accuracy_precision.png")
+    plt.savefig("leaderboard_second_third.png")
+    plt.close()
+
+
+def plot_third_place(results: List[Dict[str, float]]) -> None:
+    """Plot the accuracy of the 3rd ranked student."""
+    lb = _sort_leaderboard(results)
+    third = lb[2:3]
+
+    if not third:
+        return
+
+    name = third[0]["student"]
+    acc = third[0]["accuracy"]
+
+    plt.figure(figsize=(4, 4))
+    plt.bar([0], [acc], color="steelblue")
+    plt.xlabel("Student")
+    plt.ylabel("Accuracy")
+    plt.title("3rd Place")
+    plt.xticks([0], [name])
+    plt.ylim(0, 1)
+    plt.tight_layout()
+    plt.savefig("leaderboard_third.png")
     plt.close()
 
 
 def main() -> None:
     results = load_results(RESULTS_PATH)
-    plot_overall_accuracy(results)
-    plot_top3(results)
+    plot_leaderboard_all(results)
+    plot_second_and_third(results)
+    plot_third_place(results)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- generate three new visualizations for the leaderboard
  - all students with names and accuracy labels
  - only second and third place
  - only third place
- update README with instructions for the new charts

## Testing
- `python -m py_compile src/visualize_results.py`
- `python src/visualize_results.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6851d722ca34832993cdf6d368d1de8b